### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,4 +6,4 @@ Glassbox is a minimal API for program state introspection and detecting
 interesting behaviours.
 
 It's currently rather experimental, but you can see some basic documentation
-at https://glassbox.readthedocs.org.
+at https://glassbox.readthedocs.io.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
